### PR TITLE
Fix missing docs reference

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # welcome bot: A Probot App
 
-Fill in the blank
+Welcome bot automatically greets newcomers to your project.
 
 ## What it does
 
-Frustration
+The bot posts friendly messages on new issues and pull requests to encourage
+collaboration.
 
 ## Getting started
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,10 @@
+# Getting Started Guide
+
+This short guide will help you configure the Welcome bot for your repository.
+
+1. Install the **Welcome** app on the repositories where you want to enable friendly comments.
+2. Create a `.github/config.yml` file in your repository.
+3. Copy the sample configuration from the README into that file and customize it.
+4. Commit the file to your default branch and test by opening an issue or pull request.
+
+For more details about configuration options, see the [behaviorbot documentation](https://github.com/behaviorbot/welcome#usage).


### PR DESCRIPTION
## Summary
- fix README intro text
- add missing docs/getting-started.md
- add MIT license file

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865f1568d8c8332827177a1582f1c9c